### PR TITLE
add necessary include

### DIFF
--- a/src/profilepicturemanager.cpp
+++ b/src/profilepicturemanager.cpp
@@ -5,6 +5,7 @@
 #include <QStandardPaths>
 #include <QDir>
 #include <QPainter>
+#include <QPainterPath>
 #include <QSettings>
 
 ProfilePictureManager ProfilePictureManager::instance;


### PR DESCRIPTION
mcpelauncher-msa-ui-qt-git/src/msa-manifest/msa-ui-qt/src/profilepicturemanager.cpp:95:18: error: aggregate ‘QPainterPath clipPath’ has incomplete type and cannot be defined
   95 |     QPainterPath clipPath;
      |                  ^~~~~~~~
https://doc.qt.io/qt-5/qpainterpath.html