### PR TITLE
Make msa-ui-qt Qt5 and Qt6 Compatible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,10 +8,17 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt5 COMPONENTS Core Widgets WebEngineWidgets Network REQUIRED)
+
+set(QT_VERSION 5 CACHE STRING "Qt version to use")
+set_property(CACHE QT_VERSION PROPERTY STRINGS 5 6)
+
+set(qt-ver "Qt${QT_VERSION}")
+
+find_package(${qt-ver} COMPONENTS Core Widgets WebEngineWidgets Network REQUIRED)
+set(msa-ui-qt-libs ${qt-ver}::Core ${qt-ver}::Widgets ${qt-ver}::WebEngineWidgets ${qt-ver}::Network daemon-server-utils msa-daemon-client)
 
 add_executable(msa-ui-qt src/main.cpp src/webloginwindow.cpp src/webloginwindow.h src/materialbusyindicator.cpp src/materialbusyindicator.h src/loginipcservice.cpp src/loginipcservice.h src/loginuihandler.cpp src/loginuihandler.h src/pickaccountwindow.cpp src/pickaccountwindow.h src/msadaemonmanager.cpp src/msadaemonmanager.h src/msadaemonmanager.cpp src/profilepicturemanager.cpp src/profilepicturemanager.h msaui.qrc)
-target_link_libraries(msa-ui-qt Qt5::Core Qt5::Widgets Qt5::WebEngineWidgets Qt5::Network daemon-server-utils msa-daemon-client)
+target_link_libraries(msa-ui-qt ${msa-ui-qt-libs})
 
 if (APPLE)
     target_sources(msa-ui-qt PRIVATE src/macosutil.mm src/macosutil.h)

--- a/src/pickaccountwindow.cpp
+++ b/src/pickaccountwindow.cpp
@@ -17,11 +17,19 @@ PickAccountWindow::PickAccountWindow(QVector<PickAccountEntry> entries, QWidget*
     QPixmap defaultProfilePixmap (":/res/default_profile.svg");
 
     QVBoxLayout* layout = new QVBoxLayout(this);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     layout->setMargin(0);
+#else
+    layout->setContentsMargins(0,0,0,0);
+#endif
     QScrollArea* listScrollArea = new QScrollArea(this);
     QWidget* listWidget = new QWidget(this);
     QVBoxLayout* listLayout = new QVBoxLayout(listWidget);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     listLayout->setMargin(0);
+#else
+    listLayout->setContentsMargins(0,0,0,0);
+#endif
     listLayout->setSpacing(0);
     listWidget->setProperty("class", "pick-account-list");
     listWidget->setLayout(listLayout);
@@ -101,7 +109,11 @@ void PickAccountRow::remove() {
 
 void PickAccountRow::paintEvent(QPaintEvent* event) {
     QStyleOption opt;
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     opt.init(this);
+#else
+    opt.initFrom(this);
+#endif
     QPainter p(this);
     style()->drawPrimitive(QStyle::PE_Widget, &opt, &p, this);
     QWidget::paintEvent(event);
@@ -123,7 +135,11 @@ AddAccountRow::AddAccountRow(QWidget* parent) : ClickableWidget(parent) {
 
 void AddAccountRow::paintEvent(QPaintEvent* event) {
     QStyleOption opt;
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     opt.init(this);
+#else
+    opt.initFrom(this);
+#endif
     QPainter p(this);
     style()->drawPrimitive(QStyle::PE_Widget, &opt, &p, this);
     QWidget::paintEvent(event);


### PR DESCRIPTION
This is a very simple PR, Qt6 compatibility is quick simple for this program so not many changes are necessary. To enable Qt6 to be used instead of Qt5 (the default) simple add `-DQT_VERSION=6` to the CMake command-line, for example:

```
cmake -DENABLE_MSA_QT_UI=ON -DCMAKE_INSTALL_PREFIX=/usr -DQT_VERSION=6 ..
```